### PR TITLE
Use Sorter interface instead of abstract class

### DIFF
--- a/src/main/java/io/projects/sortingapi/Application.java
+++ b/src/main/java/io/projects/sortingapi/Application.java
@@ -21,9 +21,7 @@ public class Application {
 	@CrossOrigin()
 	public @ResponseBody List<SortFrame> sort(@RequestParam String algorithm,
 											  @RequestBody List<Integer> list) throws Exception {
-		return new SorterFactory().getSorter(algorithm)
-				.setList(list)
-				.generateSortFrames();
+		return new SorterFactory().getSorter(algorithm).generateSortFrames(list);
 	}
 
 

--- a/src/main/java/io/projects/sortingapi/sorting/sorters/BubbleSorter.java
+++ b/src/main/java/io/projects/sortingapi/sorting/sorters/BubbleSorter.java
@@ -6,9 +6,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class BubbleSorter extends Sorter {
+public class BubbleSorter implements Sorter {
 
-    public List<SortFrame> generateSortFrames() {
+    public List<SortFrame> generateSortFrames(List<Integer> list) {
+        List<SortFrame> frames = new ArrayList<>();
         if (list.size() == 0) {
             return frames;
         }
@@ -30,6 +31,6 @@ public class BubbleSorter extends Sorter {
             }
         }
         frames.add(new SortFrame(new ArrayList<>(list), null));
-        return this.frames;
+        return frames;
     }
 }

--- a/src/main/java/io/projects/sortingapi/sorting/sorters/InsertionSorter.java
+++ b/src/main/java/io/projects/sortingapi/sorting/sorters/InsertionSorter.java
@@ -6,9 +6,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class InsertionSorter extends Sorter {
+public class InsertionSorter implements Sorter {
 
-    public List<SortFrame> generateSortFrames() {
+    public List<SortFrame> generateSortFrames(List<Integer> list) {
+        List<SortFrame> frames = new ArrayList<>();
         int n = list.size();
         if (n == 0) {
             return frames;

--- a/src/main/java/io/projects/sortingapi/sorting/sorters/MergeSorter.java
+++ b/src/main/java/io/projects/sortingapi/sorting/sorters/MergeSorter.java
@@ -4,9 +4,9 @@ import io.projects.sortingapi.sorting.SortFrame;
 
 import java.util.List;
 
-public class MergeSorter extends Sorter {
+public class MergeSorter implements Sorter {
 
-    public List<SortFrame> generateSortFrames() {
-        return this.frames;
+    public List<SortFrame> generateSortFrames(List<Integer> list) {
+        return null;
     }
 }

--- a/src/main/java/io/projects/sortingapi/sorting/sorters/QuickSorter.java
+++ b/src/main/java/io/projects/sortingapi/sorting/sorters/QuickSorter.java
@@ -4,9 +4,8 @@ import io.projects.sortingapi.sorting.SortFrame;
 
 import java.util.List;
 
-public class QuickSorter extends Sorter {
+public class QuickSorter implements Sorter {
 
-    public List<SortFrame> generateSortFrames() {
-        return this.frames;
-    }
-}
+    public List<SortFrame> generateSortFrames(List<Integer> list) {
+        return null;
+    }}

--- a/src/main/java/io/projects/sortingapi/sorting/sorters/Sorter.java
+++ b/src/main/java/io/projects/sortingapi/sorting/sorters/Sorter.java
@@ -3,23 +3,8 @@ package io.projects.sortingapi.sorting.sorters;
 
 import io.projects.sortingapi.sorting.SortFrame;
 
-import java.util.ArrayList;
 import java.util.List;
 
-public abstract class Sorter {
-    public List<Integer> list = new ArrayList<>();
-    public List<SortFrame> frames = new ArrayList<>();
-
-    public Sorter setList(List<Integer> list) {
-        this.list = list;
-        return this;
-    }
-
-    public Sorter setFrames(List<SortFrame> frames) {
-        this.frames = frames;
-        return this;
-    }
-
-
-    public abstract List<SortFrame> generateSortFrames();
+public interface Sorter {
+    List<SortFrame> generateSortFrames(List<Integer> list);
 }

--- a/src/test/java/io/projects/sortingapi/unit/BubbleSortTest.java
+++ b/src/test/java/io/projects/sortingapi/unit/BubbleSortTest.java
@@ -20,7 +20,7 @@ public class BubbleSortTest {
     @Test
     void alreadySorted() {
         List<Integer> list = Stream.of(1, 2, 3, 4, 5).collect(Collectors.toList());
-        List<SortFrame> actual = new BubbleSorter().setList(list).generateSortFrames();
+        List<SortFrame> actual = new BubbleSorter().generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
         expected.add(new SortFrame(new ArrayList<>(List.of(1, 2, 3, 4, 5)), 0));
@@ -36,7 +36,7 @@ public class BubbleSortTest {
     @Test
     void reverseSorted() {
         List<Integer> list = Stream.of(5, 4, 3, 2, 1).collect(Collectors.toList());
-        List<SortFrame> actual = new BubbleSorter().setList(list).generateSortFrames();
+        List<SortFrame> actual = new BubbleSorter().generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
         expected.add(new SortFrame(new ArrayList<>(List.of(5, 4, 3, 2, 1)), 0));
@@ -62,7 +62,7 @@ public class BubbleSortTest {
     @Test
     void allSameValue() {
         List<Integer> list = Stream.of(1, 1, 1, 1, 1, 1, 1).collect(Collectors.toList());
-        List<SortFrame> actual = new BubbleSorter().setList(list).generateSortFrames();
+        List<SortFrame> actual = new BubbleSorter().generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
         expected.add(new SortFrame(new ArrayList<>(List.of(1, 1, 1, 1, 1, 1, 1)), 0));
@@ -80,7 +80,7 @@ public class BubbleSortTest {
     @Test
     void emptyList() {
         List<Integer> list = new ArrayList<>();
-        List<SortFrame> actual = new BubbleSorter().setList(list).generateSortFrames();
+        List<SortFrame> actual = new BubbleSorter().generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
 
@@ -96,13 +96,13 @@ public class BubbleSortTest {
         list.add(2);
         list.add(1);
         list.add(null);
-        List<SortFrame> actual = new BubbleSorter().setList(list).generateSortFrames();
+        List<SortFrame> actual = new BubbleSorter().generateSortFrames(list);
     }
 
     @Disabled
     @Test
     void nullList() {
         List<Integer> list = null;
-        List<SortFrame> actual = new BubbleSorter().setList(list).generateSortFrames();
+        List<SortFrame> actual = new BubbleSorter().generateSortFrames(list);
     }
 }

--- a/src/test/java/io/projects/sortingapi/unit/InsertionSortTest.java
+++ b/src/test/java/io/projects/sortingapi/unit/InsertionSortTest.java
@@ -20,7 +20,7 @@ public class InsertionSortTest {
     @Test
     void alreadySorted() {
         List<Integer> list = Stream.of(1, 2, 3, 4, 5).collect(Collectors.toList());
-        List<SortFrame> actual = new InsertionSorter().setList(list).generateSortFrames();
+        List<SortFrame> actual = new InsertionSorter().generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
         expected.add(new SortFrame(new ArrayList<>(List.of(1, 2, 3, 4, 5)), 0));
@@ -36,7 +36,7 @@ public class InsertionSortTest {
     @Test
     void reverseSorted() {
         List<Integer> list = Stream.of(5, 4, 3, 2, 1).collect(Collectors.toList());
-        List<SortFrame> actual = new InsertionSorter().setList(list).generateSortFrames();
+        List<SortFrame> actual = new InsertionSorter().generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
         expected.add(new SortFrame(new ArrayList<>(List.of(5, 4, 3, 2, 1)), 0));
@@ -62,7 +62,7 @@ public class InsertionSortTest {
     @Test
     void allSameValue() {
         List<Integer> list = Stream.of(1, 1, 1, 1, 1, 1, 1).collect(Collectors.toList());
-        List<SortFrame> actual = new InsertionSorter().setList(list).generateSortFrames();
+        List<SortFrame> actual = new InsertionSorter().generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
         expected.add(new SortFrame(new ArrayList<>(List.of(1, 1, 1, 1, 1, 1, 1)), 0));
@@ -80,7 +80,7 @@ public class InsertionSortTest {
     @Test
     void emptyList() {
         List<Integer> list = new ArrayList<>();
-        List<SortFrame> actual = new InsertionSorter().setList(list).generateSortFrames();
+        List<SortFrame> actual = new InsertionSorter().generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
 
@@ -96,13 +96,13 @@ public class InsertionSortTest {
         list.add(2);
         list.add(1);
         list.add(null);
-        List<SortFrame> actual = new InsertionSorter().setList(list).generateSortFrames();
+        List<SortFrame> actual = new InsertionSorter().generateSortFrames(list);
     }
 
     @Disabled
     @Test
     void nullList() {
         List<Integer> list = null;
-        List<SortFrame> actual = new InsertionSorter().setList(list).generateSortFrames();
+        List<SortFrame> actual = new InsertionSorter().generateSortFrames(list);
     }
 }


### PR DESCRIPTION
Sorting can be more easily handled by implementations of the Sorter interface, with one method to generate the frames.  There is no need for inheritance, at least for now, so no need for abstract class.