### PR TITLE
Create sorters and factory as singleton beans to reduce new object creation

### DIFF
--- a/src/main/java/io/projects/sortingapi/Application.java
+++ b/src/main/java/io/projects/sortingapi/Application.java
@@ -2,6 +2,7 @@ package io.projects.sortingapi;
 
 import io.projects.sortingapi.sorting.SortFrame;
 import io.projects.sortingapi.sorting.SorterFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.bind.annotation.*;
@@ -16,12 +17,14 @@ public class Application {
 		SpringApplication.run(Application.class, args);
 	}
 
+	@Autowired
+	SorterFactory sorterFactory;
 
 	@PostMapping("/sort")
 	@CrossOrigin()
 	public @ResponseBody List<SortFrame> sort(@RequestParam String algorithm,
 											  @RequestBody List<Integer> list) throws Exception {
-		return new SorterFactory().getSorter(algorithm).generateSortFrames(list);
+		return sorterFactory.getSorter(algorithm).generateSortFrames(list);
 	}
 
 

--- a/src/main/java/io/projects/sortingapi/Application.java
+++ b/src/main/java/io/projects/sortingapi/Application.java
@@ -17,8 +17,11 @@ public class Application {
 		SpringApplication.run(Application.class, args);
 	}
 
-	@Autowired
-	SorterFactory sorterFactory;
+	private final SorterFactory sorterFactory;
+
+	public Application(SorterFactory sorterFactory) {
+		this.sorterFactory = sorterFactory;
+	}
 
 	@PostMapping("/sort")
 	@CrossOrigin()

--- a/src/main/java/io/projects/sortingapi/sorting/SorterFactory.java
+++ b/src/main/java/io/projects/sortingapi/sorting/SorterFactory.java
@@ -1,17 +1,36 @@
 package io.projects.sortingapi.sorting;
 
 import io.projects.sortingapi.sorting.sorters.*;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
 public class SorterFactory {
+    private final Sorter insertionSorter;
+    private final Sorter bubbleSorter;
+    private final Sorter mergeSorter;
+    private final Sorter quickSorter;
+
+    public SorterFactory(Sorter insertionSorter, Sorter bubbleSorter,
+                         Sorter mergeSorter, Sorter quickSorter) {
+        this.insertionSorter = insertionSorter;
+        this.bubbleSorter = bubbleSorter;
+        this.mergeSorter = mergeSorter;
+        this.quickSorter = quickSorter;
+    }
+
     public Sorter getSorter(String algorithm) throws Exception {
         if (algorithm.equalsIgnoreCase("insertion")) {
-            return new InsertionSorter();
+            System.out.println(insertionSorter.toString());
+            return insertionSorter;
         } else if (algorithm.equalsIgnoreCase("bubble")) {
-            return new BubbleSorter();
+            return bubbleSorter;
         } else if (algorithm.equalsIgnoreCase("merge")) {
-            return new MergeSorter();
+            return mergeSorter;
         } else if (algorithm.equalsIgnoreCase("quick")) {
-            return new QuickSorter();
+            return quickSorter;
         }
         throw new IllegalArgumentException(algorithm + " is not a supported algorithm!");
     }

--- a/src/main/java/io/projects/sortingapi/sorting/sorters/BubbleSorter.java
+++ b/src/main/java/io/projects/sortingapi/sorting/sorters/BubbleSorter.java
@@ -1,11 +1,16 @@
 package io.projects.sortingapi.sorting.sorters;
 
 import io.projects.sortingapi.sorting.SortFrame;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
 public class BubbleSorter implements Sorter {
 
     public List<SortFrame> generateSortFrames(List<Integer> list) {

--- a/src/main/java/io/projects/sortingapi/sorting/sorters/InsertionSorter.java
+++ b/src/main/java/io/projects/sortingapi/sorting/sorters/InsertionSorter.java
@@ -1,11 +1,16 @@
 package io.projects.sortingapi.sorting.sorters;
 
 import io.projects.sortingapi.sorting.SortFrame;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
 public class InsertionSorter implements Sorter {
 
     public List<SortFrame> generateSortFrames(List<Integer> list) {

--- a/src/main/java/io/projects/sortingapi/sorting/sorters/MergeSorter.java
+++ b/src/main/java/io/projects/sortingapi/sorting/sorters/MergeSorter.java
@@ -1,9 +1,14 @@
 package io.projects.sortingapi.sorting.sorters;
 
 import io.projects.sortingapi.sorting.SortFrame;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
 public class MergeSorter implements Sorter {
 
     public List<SortFrame> generateSortFrames(List<Integer> list) {

--- a/src/main/java/io/projects/sortingapi/sorting/sorters/QuickSorter.java
+++ b/src/main/java/io/projects/sortingapi/sorting/sorters/QuickSorter.java
@@ -1,9 +1,14 @@
 package io.projects.sortingapi.sorting.sorters;
 
 import io.projects.sortingapi.sorting.SortFrame;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
 public class QuickSorter implements Sorter {
 
     public List<SortFrame> generateSortFrames(List<Integer> list) {

--- a/src/test/java/io/projects/sortingapi/unit/BubbleSortTest.java
+++ b/src/test/java/io/projects/sortingapi/unit/BubbleSortTest.java
@@ -1,9 +1,10 @@
 package io.projects.sortingapi.unit;
 
 import io.projects.sortingapi.sorting.SortFrame;
-import io.projects.sortingapi.sorting.sorters.BubbleSorter;
+import io.projects.sortingapi.sorting.sorters.Sorter;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.ArrayList;
@@ -17,10 +18,13 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 public class BubbleSortTest {
 
+    @Autowired
+    Sorter bubbleSorter;
+
     @Test
     void alreadySorted() {
         List<Integer> list = Stream.of(1, 2, 3, 4, 5).collect(Collectors.toList());
-        List<SortFrame> actual = new BubbleSorter().generateSortFrames(list);
+        List<SortFrame> actual = bubbleSorter.generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
         expected.add(new SortFrame(new ArrayList<>(List.of(1, 2, 3, 4, 5)), 0));
@@ -36,7 +40,7 @@ public class BubbleSortTest {
     @Test
     void reverseSorted() {
         List<Integer> list = Stream.of(5, 4, 3, 2, 1).collect(Collectors.toList());
-        List<SortFrame> actual = new BubbleSorter().generateSortFrames(list);
+        List<SortFrame> actual = bubbleSorter.generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
         expected.add(new SortFrame(new ArrayList<>(List.of(5, 4, 3, 2, 1)), 0));
@@ -62,7 +66,7 @@ public class BubbleSortTest {
     @Test
     void allSameValue() {
         List<Integer> list = Stream.of(1, 1, 1, 1, 1, 1, 1).collect(Collectors.toList());
-        List<SortFrame> actual = new BubbleSorter().generateSortFrames(list);
+        List<SortFrame> actual = bubbleSorter.generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
         expected.add(new SortFrame(new ArrayList<>(List.of(1, 1, 1, 1, 1, 1, 1)), 0));
@@ -80,7 +84,7 @@ public class BubbleSortTest {
     @Test
     void emptyList() {
         List<Integer> list = new ArrayList<>();
-        List<SortFrame> actual = new BubbleSorter().generateSortFrames(list);
+        List<SortFrame> actual = bubbleSorter.generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
 
@@ -96,13 +100,13 @@ public class BubbleSortTest {
         list.add(2);
         list.add(1);
         list.add(null);
-        List<SortFrame> actual = new BubbleSorter().generateSortFrames(list);
+        List<SortFrame> actual = bubbleSorter.generateSortFrames(list);
     }
 
     @Disabled
     @Test
     void nullList() {
         List<Integer> list = null;
-        List<SortFrame> actual = new BubbleSorter().generateSortFrames(list);
+        List<SortFrame> actual = bubbleSorter.generateSortFrames(list);
     }
 }

--- a/src/test/java/io/projects/sortingapi/unit/InsertionSortTest.java
+++ b/src/test/java/io/projects/sortingapi/unit/InsertionSortTest.java
@@ -1,9 +1,10 @@
 package io.projects.sortingapi.unit;
 
 import io.projects.sortingapi.sorting.SortFrame;
-import io.projects.sortingapi.sorting.sorters.InsertionSorter;
+import io.projects.sortingapi.sorting.sorters.Sorter;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.ArrayList;
@@ -17,10 +18,12 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 public class InsertionSortTest {
 
+    @Autowired
+    Sorter insertionSorter;
     @Test
     void alreadySorted() {
         List<Integer> list = Stream.of(1, 2, 3, 4, 5).collect(Collectors.toList());
-        List<SortFrame> actual = new InsertionSorter().generateSortFrames(list);
+        List<SortFrame> actual = insertionSorter.generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
         expected.add(new SortFrame(new ArrayList<>(List.of(1, 2, 3, 4, 5)), 0));
@@ -36,7 +39,7 @@ public class InsertionSortTest {
     @Test
     void reverseSorted() {
         List<Integer> list = Stream.of(5, 4, 3, 2, 1).collect(Collectors.toList());
-        List<SortFrame> actual = new InsertionSorter().generateSortFrames(list);
+        List<SortFrame> actual = insertionSorter.generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
         expected.add(new SortFrame(new ArrayList<>(List.of(5, 4, 3, 2, 1)), 0));
@@ -62,7 +65,7 @@ public class InsertionSortTest {
     @Test
     void allSameValue() {
         List<Integer> list = Stream.of(1, 1, 1, 1, 1, 1, 1).collect(Collectors.toList());
-        List<SortFrame> actual = new InsertionSorter().generateSortFrames(list);
+        List<SortFrame> actual = insertionSorter.generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
         expected.add(new SortFrame(new ArrayList<>(List.of(1, 1, 1, 1, 1, 1, 1)), 0));
@@ -80,7 +83,7 @@ public class InsertionSortTest {
     @Test
     void emptyList() {
         List<Integer> list = new ArrayList<>();
-        List<SortFrame> actual = new InsertionSorter().generateSortFrames(list);
+        List<SortFrame> actual = insertionSorter.generateSortFrames(list);
 
         List<SortFrame> expected = new ArrayList<>();
 
@@ -96,13 +99,13 @@ public class InsertionSortTest {
         list.add(2);
         list.add(1);
         list.add(null);
-        List<SortFrame> actual = new InsertionSorter().generateSortFrames(list);
+        List<SortFrame> actual = insertionSorter.generateSortFrames(list);
     }
 
     @Disabled
     @Test
     void nullList() {
         List<Integer> list = null;
-        List<SortFrame> actual = new InsertionSorter().generateSortFrames(list);
+        List<SortFrame> actual = insertionSorter.generateSortFrames(list);
     }
 }


### PR DESCRIPTION
- Sorters create as singleton beans at startup to be managed by Spring IoC container.
- SorterFactory autowires in those beans and routes to them, instead of creating new instance with each request.
- Injection done via constructor in order to keep Sorters private and final